### PR TITLE
Use zod's JSON Schema type, and implement better array support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "zod-from-json-schema",
-    "version": "0.0.5",
+    "version": "0.4.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "zod-from-json-schema",
-            "version": "0.0.5",
+            "version": "0.4.1",
             "license": "MIT",
             "dependencies": {
                 "zod": "^3.25.25"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "zod-from-json-schema",
-    "version": "0.4.0",
+    "version": "0.4.1",
     "description": "Creates Zod types from JSON Schema at runtime",
     "main": "dist/index.js",
     "module": "dist/index.mjs",

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -820,6 +820,199 @@ describe("convertJsonSchemaToZod", () => {
         ]);
       });
     });
+
+    describe("prefixItems (Draft 2020-12 tuples)", () => {
+      it("should handle prefixItems with different types", () => {
+        const jsonSchema = {
+          $schema: "https://json-schema.org/draft/2020-12/schema",
+          type: "array",
+          prefixItems: [
+            { type: "string" },
+            { type: "number" },
+            { type: "boolean" }
+          ]
+        };
+
+        const zodSchema = convertJsonSchemaToZod(jsonSchema);
+
+        // Valid tuple should pass
+        expect(() => zodSchema.parse(["hello", 42, true])).not.toThrow();
+        
+        // Wrong types should fail
+        expect(() => zodSchema.parse([42, "hello", true])).toThrow();
+        expect(() => zodSchema.parse(["hello", "world", true])).toThrow();
+        
+        // Partial tuples should be allowed - prefixItems doesn't require all items
+        expect(() => zodSchema.parse(["hello"])).not.toThrow();
+        expect(() => zodSchema.parse(["hello", 42])).not.toThrow();
+        
+        // Additional items should be allowed by default with prefixItems
+        expect(() => zodSchema.parse(["hello", 42, true, "extra"])).not.toThrow();
+        expect(() => zodSchema.parse(["hello", 42, true, 999, { any: "thing" }])).not.toThrow();
+      });
+
+      it("should handle prefixItems with single item type", () => {
+        const jsonSchema = {
+          $schema: "https://json-schema.org/draft/2020-12/schema",
+          type: "array",
+          prefixItems: [
+            { type: "string" }
+          ]
+        };
+
+        const zodSchema = convertJsonSchemaToZod(jsonSchema);
+
+        expect(() => zodSchema.parse(["hello"])).not.toThrow();
+        expect(() => zodSchema.parse([42])).toThrow();
+        expect(() => zodSchema.parse(["hello", "world"])).not.toThrow(); // extra items allowed
+        expect(() => zodSchema.parse([])).not.toThrow(); // empty array is valid - no items required
+      });
+
+      it("should handle empty prefixItems array", () => {
+        const jsonSchema = {
+          $schema: "https://json-schema.org/draft/2020-12/schema",
+          type: "array",
+          prefixItems: []
+        };
+
+        const zodSchema = convertJsonSchemaToZod(jsonSchema);
+
+        expect(() => zodSchema.parse([])).not.toThrow();
+        expect(() => zodSchema.parse(["anything"])).not.toThrow(); // extra items allowed with empty prefixItems
+        expect(() => zodSchema.parse([1, 2, 3])).not.toThrow();
+      });
+
+      it("should handle prefixItems with complex nested types", () => {
+        const jsonSchema = {
+          $schema: "https://json-schema.org/draft/2020-12/schema",
+          type: "array",
+          prefixItems: [
+            { 
+              type: "object",
+              properties: {
+                id: { type: "number" },
+                name: { type: "string" }
+              },
+              required: ["id", "name"]
+            },
+            { 
+              type: "array",
+              items: { type: "string" }
+            },
+            { type: "number", minimum: 0, maximum: 100 }
+          ]
+        };
+
+        const zodSchema = convertJsonSchemaToZod(jsonSchema);
+
+        // Valid tuple should pass
+        expect(() => zodSchema.parse([
+          { id: 1, name: "Alice" },
+          ["tag1", "tag2"],
+          50
+        ])).not.toThrow();
+        
+        // Invalid object should fail
+        expect(() => zodSchema.parse([
+          { name: "Alice" }, // missing id
+          ["tag1", "tag2"],
+          50
+        ])).toThrow();
+        
+        // Invalid array should fail
+        expect(() => zodSchema.parse([
+          { id: 1, name: "Alice" },
+          ["tag1", 123], // number in string array
+          50
+        ])).toThrow();
+        
+        // Invalid number should fail
+        expect(() => zodSchema.parse([
+          { id: 1, name: "Alice" },
+          ["tag1", "tag2"],
+          150 // exceeds maximum
+        ])).toThrow();
+      });
+
+      it("should validate prefixItems behavior correctly", () => {
+        const jsonSchema = {
+          $schema: "https://json-schema.org/draft/2020-12/schema",
+          type: "array",
+          prefixItems: [
+            { type: "string" },
+            { type: "number" }
+          ]
+        };
+
+        const zodSchema = convertJsonSchemaToZod(jsonSchema);
+        
+        // Test the behavior instead of schema round-trip since we use custom validation
+        expect(() => zodSchema.parse(["hello", 42])).not.toThrow();
+        expect(() => zodSchema.parse(["hello"])).not.toThrow();
+        expect(() => zodSchema.parse([])).not.toThrow();
+        expect(() => zodSchema.parse(["hello", 42, "extra"])).not.toThrow();
+        expect(() => zodSchema.parse([42, "hello"])).toThrow();
+      });
+
+      it("should handle prefixItems with constraints", () => {
+        const jsonSchema = {
+          $schema: "https://json-schema.org/draft/2020-12/schema",
+          type: "array",
+          prefixItems: [
+            { type: "string", minLength: 2 },
+            { type: "number", minimum: 0 }
+          ],
+          minItems: 2,
+          maxItems: 2
+        };
+
+        const zodSchema = convertJsonSchemaToZod(jsonSchema);
+
+        expect(() => zodSchema.parse(["hi", 5])).not.toThrow();
+        expect(() => zodSchema.parse(["a", 5])).toThrow(); // string too short
+        expect(() => zodSchema.parse(["hi", -1])).toThrow(); // number too small
+      });
+
+      it("should handle prefixItems with items: false (strict tuple)", () => {
+        const jsonSchema = {
+          $schema: "https://json-schema.org/draft/2020-12/schema",
+          type: "array",
+          prefixItems: [
+            { type: "string" },
+            { type: "number" }
+          ],
+          items: false
+        };
+
+        const zodSchema = convertJsonSchemaToZod(jsonSchema);
+
+        expect(() => zodSchema.parse(["hello", 42])).not.toThrow();
+        expect(() => zodSchema.parse(["hello", 42, "extra"])).toThrow(); // no additional items allowed
+        expect(() => zodSchema.parse(["hello"])).not.toThrow(); // partial tuple OK
+        expect(() => zodSchema.parse([])).not.toThrow(); // empty array OK
+      });
+
+      it("should handle prefixItems with items schema (constrained additional items)", () => {
+        const jsonSchema = {
+          $schema: "https://json-schema.org/draft/2020-12/schema",
+          type: "array",
+          prefixItems: [
+            { type: "string" },
+            { type: "number" }
+          ],
+          items: { type: "boolean" }
+        };
+
+        const zodSchema = convertJsonSchemaToZod(jsonSchema);
+
+        expect(() => zodSchema.parse(["hello", 42])).not.toThrow();
+        expect(() => zodSchema.parse(["hello", 42, true])).not.toThrow();
+        expect(() => zodSchema.parse(["hello", 42, true, false])).not.toThrow();
+        expect(() => zodSchema.parse(["hello", 42, "string"])).toThrow(); // additional item wrong type
+        expect(() => zodSchema.parse(["hello"])).not.toThrow(); // partial tuple OK
+        expect(() => zodSchema.parse([])).not.toThrow(); // empty array OK
+      });
+    });
   });
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,44 +1,12 @@
 import { z } from "zod/v4";
-
-/**
- * Type representing a JSON Schema object
- */
-// FIXME: use zod's JSON Schema type for this
-export type JSONSchema = {
-    $schema?: string;
-    type?: string;
-    properties?: Partial<Record<string, JSONSchema>>;
-    required?: string[];
-    additionalProperties?: boolean;
-    items?: JSONSchema;
-    enum?: Array<string | number | boolean | null>;
-    const?: any;
-    description?: string;
-    anyOf?: JSONSchema[];
-    allOf?: JSONSchema[];
-    oneOf?: JSONSchema[];
-    // String validations
-    minLength?: number;
-    maxLength?: number;
-    pattern?: string;
-    // Number validations
-    minimum?: number;
-    maximum?: number;
-    exclusiveMinimum?: number;
-    exclusiveMaximum?: number;
-    multipleOf?: number;
-    // Array validations
-    minItems?: number;
-    maxItems?: number;
-    uniqueItems?: boolean;
-};
+import type { JSONSchema } from "zod/v4/core";
 
 /**
  * Converts a JSON Schema object to a Zod schema
  */
-export function convertJsonSchemaToZod(schema: JSONSchema): z.ZodType {
+export function convertJsonSchemaToZod(schema: JSONSchema.BaseSchema): z.ZodType {
     // Create a helper function to add metadata like description
-    function addMetadata(zodSchema: z.ZodTypeAny, jsonSchema: JSONSchema): z.ZodTypeAny {
+    function addMetadata(zodSchema: z.ZodTypeAny, jsonSchema: JSONSchema.BaseSchema): z.ZodTypeAny {
         if (jsonSchema.description) {
             zodSchema = zodSchema.describe(jsonSchema.description);
         }
@@ -64,77 +32,81 @@ export function convertJsonSchemaToZod(schema: JSONSchema): z.ZodType {
     if (schema.type) {
         switch (schema.type) {
             case "string": {
+                const s = schema as JSONSchema.StringSchema;
+
                 // Handle enum first if it exists for string type
-                if (schema.enum) {
+                if (s.enum) {
                     // Empty enum case, default to string type
-                    if (schema.enum.length === 0) {
-                        return addMetadata(z.string(), schema);
+                    if (s.enum.length === 0) {
+                        return addMetadata(z.string(), s);
                     }
 
                     // Since we know this is a string type, we can safely cast enum values
-                    return addMetadata(z.enum(schema.enum as [string, ...string[]]), schema);
+                    return addMetadata(z.enum(s.enum as [string, ...string[]]), s);
                 }
 
                 let stringSchema = z.string();
 
                 // Apply string-specific constraints
-                if (schema.minLength !== undefined) {
-                    stringSchema = stringSchema.min(schema.minLength);
+                if (s.minLength !== undefined) {
+                    stringSchema = stringSchema.min(s.minLength);
                 }
-                if (schema.maxLength !== undefined) {
-                    stringSchema = stringSchema.max(schema.maxLength);
+                if (s.maxLength !== undefined) {
+                    stringSchema = stringSchema.max(s.maxLength);
                 }
-                if (schema.pattern !== undefined) {
-                    const regex = new RegExp(schema.pattern);
+                if (s.pattern !== undefined) {
+                    const regex = new RegExp(s.pattern);
                     stringSchema = stringSchema.regex(regex);
                 }
 
-                return addMetadata(stringSchema, schema);
+                return addMetadata(stringSchema, s);
             }
             case "number":
             case "integer": {
+                const s = schema as JSONSchema.NumberSchema | JSONSchema.IntegerSchema;
+
                 // Handle enum if it exists for number type
-                if (schema.enum) {
+                if (s.enum) {
                     // Empty enum case, default to number type
-                    if (schema.enum.length === 0) {
-                        return addMetadata(z.number(), schema);
+                    if (s.enum.length === 0) {
+                        return addMetadata(z.number(), s);
                     }
 
                     // For numbers we need a union of literals since z.enum only works with strings
-                    const options = schema.enum.map((val) => z.literal(val as number));
+                    const options = s.enum.map((val) => z.literal(val as number));
 
                     // Handle single option enum specially
                     if (options.length === 1) {
-                        return addMetadata(options[0], schema);
+                        return addMetadata(options[0], s);
                     }
 
                     // For multiple options, create a union
                     if (options.length >= 2) {
                         const unionSchema = z.union([options[0], options[1], ...options.slice(2)]);
-                        return addMetadata(unionSchema, schema);
+                        return addMetadata(unionSchema, s);
                     }
                 }
 
-                let numberSchema = schema.type === "integer" ? z.number().int() : z.number();
+                let numberSchema = s.type === "integer" ? z.number().int() : z.number();
 
                 // Apply number-specific constraints
-                if (schema.minimum !== undefined) {
-                    numberSchema = numberSchema.min(schema.minimum);
+                if (s.minimum !== undefined) {
+                    numberSchema = numberSchema.min(s.minimum);
                 }
-                if (schema.maximum !== undefined) {
-                    numberSchema = numberSchema.max(schema.maximum);
+                if (s.maximum !== undefined) {
+                    numberSchema = numberSchema.max(s.maximum);
                 }
-                if (schema.exclusiveMinimum !== undefined) {
-                    numberSchema = numberSchema.gt(schema.exclusiveMinimum);
+                if (s.exclusiveMinimum !== undefined) {
+                    numberSchema = numberSchema.gt(s.exclusiveMinimum);
                 }
-                if (schema.exclusiveMaximum !== undefined) {
-                    numberSchema = numberSchema.lt(schema.exclusiveMaximum);
+                if (s.exclusiveMaximum !== undefined) {
+                    numberSchema = numberSchema.lt(s.exclusiveMaximum);
                 }
-                if (schema.multipleOf !== undefined) {
-                    numberSchema = numberSchema.multipleOf(schema.multipleOf);
+                if (s.multipleOf !== undefined) {
+                    numberSchema = numberSchema.multipleOf(s.multipleOf);
                 }
 
-                return addMetadata(numberSchema, schema);
+                return addMetadata(numberSchema, s);
             }
             case "boolean":
                 // Handle enum for boolean type if present
@@ -202,21 +174,25 @@ export function convertJsonSchemaToZod(schema: JSONSchema): z.ZodType {
                 }
                 return addMetadata(z.object({}), schema);
             case "array": {
+                const s = schema as JSONSchema.ArraySchema;
+
                 let arraySchema;
-                if (schema.items) {
-                    arraySchema = z.array(convertJsonSchemaToZod(schema.items));
+                if (Array.isArray(s.items)) {
+                    throw new Error("FIXME: implement this case, which describes a tuple");
+                } else if (s.items) {
+                    arraySchema = z.array(convertJsonSchemaToZod(s.items));
                 } else {
                     arraySchema = z.array(z.any());
                 }
 
                 // Apply array-specific constraints
-                if (schema.minItems !== undefined) {
-                    arraySchema = arraySchema.min(schema.minItems);
+                if (s.minItems !== undefined) {
+                    arraySchema = arraySchema.min(s.minItems);
                 }
-                if (schema.maxItems !== undefined) {
-                    arraySchema = arraySchema.max(schema.maxItems);
+                if (s.maxItems !== undefined) {
+                    arraySchema = arraySchema.max(s.maxItems);
                 }
-                if (schema.uniqueItems === true) {
+                if (s.uniqueItems === true) {
                     // To enforce uniqueness, we need a custom refine function
                     // that checks if all elements are unique
                     arraySchema = arraySchema.refine(
@@ -241,7 +217,7 @@ export function convertJsonSchemaToZod(schema: JSONSchema): z.ZodType {
                     );
                 }
 
-                return addMetadata(arraySchema, schema);
+                return addMetadata(arraySchema, s);
             }
         }
     }
@@ -286,7 +262,7 @@ export function convertJsonSchemaToZod(schema: JSONSchema): z.ZodType {
     if (schema.allOf) {
         return addMetadata(
             schema.allOf.reduce(
-                (acc: z.ZodTypeAny, s: JSONSchema) => z.intersection(acc, convertJsonSchemaToZod(s)),
+                (acc: z.ZodTypeAny, s: JSONSchema.BaseSchema) => z.intersection(acc, convertJsonSchemaToZod(s)),
                 z.object({}),
             ),
             schema,
@@ -307,7 +283,7 @@ export function convertJsonSchemaToZod(schema: JSONSchema): z.ZodType {
  * @param schema The JSON Schema object to convert
  * @returns A Zod raw shape for use with z.object()
  */
-export function jsonSchemaObjectToZodRawShape(schema: JSONSchema): z.ZodRawShape {
+export function jsonSchemaObjectToZodRawShape(schema: JSONSchema.Schema): z.ZodRawShape {
     const raw: Record<string, z.ZodType> = {};
     for (const [key, value] of Object.entries(schema.properties ?? {})) {
         if (value === undefined) continue;

--- a/src/index.ts
+++ b/src/index.ts
@@ -178,7 +178,9 @@ export function convertJsonSchemaToZod(schema: JSONSchema.BaseSchema): z.ZodType
 
                 let arraySchema;
                 if (Array.isArray(s.items)) {
-                    throw new Error("FIXME: implement this case, which describes a tuple");
+                    // Handle tuple arrays - items is an array of schemas
+                    const tupleItems = s.items.map(itemSchema => convertJsonSchemaToZod(itemSchema));
+                    arraySchema = z.tuple(tupleItems as [z.ZodTypeAny, ...z.ZodTypeAny[]]);
                 } else if (s.items) {
                     arraySchema = z.array(convertJsonSchemaToZod(s.items));
                 } else {


### PR DESCRIPTION
- **Use zod's JSON schema type**
- **Handle tuples, too**
- **Support `prefixItems`**
- **Bump version to `0.4.1`**
