### PR TITLE
Add metaForSchema conversion option to preserve custom metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,21 +126,23 @@ try {
 
 ## API Reference
 
-### `convertJsonSchemaToZod(schema)`
+### `convertJsonSchemaToZod(schema, options?)`
 
 Converts a JSON Schema object to a complete Zod schema.
 
 - **Parameters**:
   - `schema` (Object): A JSON Schema object
+  - `options` (Object, optional): Conversion options (see [Conversion Options](#conversion-options))
 - **Returns**:
   - A Zod schema that validates according to the JSON Schema
 
-### `jsonSchemaObjectToZodRawShape(schema)`
+### `jsonSchemaObjectToZodRawShape(schema, options?)`
 
 Extracts the object properties from a JSON Schema object into a Zod raw shape. This is useful when you want to combine the properties with other Zod object configurations.
 
 - **Parameters**:
   - `schema` (Object): A JSON Schema object that should have a `properties` field
+  - `options` (Object, optional): Conversion options (see [Conversion Options](#conversion-options))
 - **Returns**:
   - A `ZodRawShape` object that can be used with `z.object()`
 
@@ -170,6 +172,44 @@ const customSchema = z.object({
   message: "Age must be over 18 to continue"
 });
 ```
+
+### Conversion Options
+
+Both `convertJsonSchemaToZod` and `jsonSchemaObjectToZodRawShape` accept an optional second argument:
+
+#### `metaForSchema`
+
+A callback that lets you attach custom [Zod metadata](https://zod.dev/metadata) to the generated schemas, for example to preserve non-standard JSON Schema keys such as UI hints or documentation fields. It is called for every JSON Schema node that produces a Zod type, including nested ones (object properties, array items, union members, etc.). If it returns a non-empty object, that object is attached to the resulting Zod type via `.meta()`. The metadata is merged with the schema's `description`; a `description` key in the returned object takes precedence.
+
+```typescript
+import { convertJsonSchemaToZod } from 'zod-from-json-schema';
+
+const jsonSchema = {
+  type: "string",
+  description: "User name",
+  "x-ui-label": "Name",
+  "x-form-position": 1
+};
+
+// Preserve all "x-" prefixed keys as Zod metadata
+const zodSchema = convertJsonSchemaToZod(jsonSchema, {
+  metaForSchema: (schema) => {
+    const meta = Object.fromEntries(
+      Object.entries(schema).filter(([key]) => key.startsWith("x-"))
+    );
+    return Object.keys(meta).length > 0 ? meta : undefined;
+  }
+});
+
+zodSchema.meta();
+// => { description: "User name", "x-ui-label": "Name", "x-form-position": 1 }
+```
+
+Notes:
+
+- The callback must be pure and cheap: a schema node may be converted (and the callback invoked) more than once, and some resulting Zod types are only used internally for validation.
+- Boolean schemas (`true`/`false`) never trigger the callback, since they have no keys to harvest.
+- Metadata is attached to the Zod type a node produces directly; wrappers added afterwards (such as `.optional()` for non-required properties) sit outside it.
 
 ## Supported JSON Schema Features
 

--- a/src/core/converter.ts
+++ b/src/core/converter.ts
@@ -1,6 +1,6 @@
 import { z } from "zod/v4";
 import type { JSONSchema } from "zod/v4/core";
-import { PrimitiveHandler, RefinementHandler, TypeSchemas } from "./types";
+import { ConversionOptions, PrimitiveHandler, RefinementHandler, TypeSchemas } from "./types";
 
 // Import primitive handlers
 import { TypeHandler } from "../handlers/primitive/type";
@@ -114,8 +114,13 @@ const refinementHandlers: RefinementHandler[] = [
 
 /**
  * Converts a JSON Schema object to a Zod schema using the two-phase architecture
+ * @param schema The JSON Schema object to convert
+ * @param options Optional conversion options
  */
-export function convertJsonSchemaToZod(schema: JSONSchema.BaseSchema | boolean): z.ZodTypeAny {
+export function convertJsonSchemaToZod(
+    schema: JSONSchema.BaseSchema | boolean,
+    options: ConversionOptions = {},
+): z.ZodTypeAny {
     // Handle boolean schemas
     if (typeof schema === "boolean") {
         return schema ? z.any() : z.never();
@@ -125,7 +130,7 @@ export function convertJsonSchemaToZod(schema: JSONSchema.BaseSchema | boolean):
     const types: TypeSchemas = {};
 
     for (const handler of primitiveHandlers) {
-        handler.apply(types, schema);
+        handler.apply(types, schema, options);
     }
 
     // Build array of allowed type schemas
@@ -187,7 +192,7 @@ export function convertJsonSchemaToZod(schema: JSONSchema.BaseSchema | boolean):
 
     // Phase 2: Apply refinement handlers
     for (const handler of refinementHandlers) {
-        zodSchema = handler.apply(zodSchema, schema);
+        zodSchema = handler.apply(zodSchema, schema, options);
     }
 
     return zodSchema;

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -12,10 +12,26 @@ export interface TypeSchemas {
     file?: z.ZodFile | false;
 }
 
+/**
+ * Options for converting a JSON Schema to a Zod schema.
+ */
+export interface ConversionOptions {
+    /**
+     * Called for every (non-boolean) JSON Schema node that produces a Zod
+     * type. If it returns a non-empty object, that object is attached to the
+     * resulting Zod type via `.meta()`, merging with the schema's
+     * `description` (a `description` key in the returned object wins).
+     *
+     * The callback must be pure: a node may be converted more than once, and
+     * some resulting Zod types are only used internally for validation.
+     */
+    metaForSchema?: (schema: JSONSchema.BaseSchema) => Record<string, unknown> | undefined;
+}
+
 export interface PrimitiveHandler {
-    apply(types: TypeSchemas, schema: JSONSchema.BaseSchema): void;
+    apply(types: TypeSchemas, schema: JSONSchema.BaseSchema, options: ConversionOptions): void;
 }
 
 export interface RefinementHandler {
-    apply(zodSchema: z.ZodTypeAny, schema: JSONSchema.BaseSchema): z.ZodTypeAny;
+    apply(zodSchema: z.ZodTypeAny, schema: JSONSchema.BaseSchema, options: ConversionOptions): z.ZodTypeAny;
 }

--- a/src/coverage-100-surgical.test.ts
+++ b/src/coverage-100-surgical.test.ts
@@ -19,7 +19,7 @@ describe("100% Coverage - Surgical Tests", () => {
             handler.apply(types, {
                 type: "array",
                 items: [{ type: "string" }, { type: "number" }] // Array items
-            });
+            }, {});
             
             expect(types.array).toBeDefined();
             expect(types.array).toBeInstanceOf(z.ZodArray);
@@ -48,7 +48,7 @@ describe("100% Coverage - Surgical Tests", () => {
             handler.apply(types, {
                 type: "array",
                 items: [{ type: "string" }]
-            });
+            }, {});
             
             // array should remain false, tuple should not be set
             expect(types.array).toBe(false);

--- a/src/handlers/primitive/array.ts
+++ b/src/handlers/primitive/array.ts
@@ -1,6 +1,6 @@
 import { z } from "zod/v4";
 import type { JSONSchema } from "zod/v4/core";
-import { PrimitiveHandler, TypeSchemas } from "../../core/types";
+import { ConversionOptions, PrimitiveHandler, TypeSchemas } from "../../core/types";
 import { convertJsonSchemaToZod } from "../../core/converter";
 
 export class ImplicitArrayHandler implements PrimitiveHandler {
@@ -46,7 +46,7 @@ export class MaxItemsHandler implements PrimitiveHandler {
 }
 
 export class ItemsHandler implements PrimitiveHandler {
-    apply(types: TypeSchemas, schema: JSONSchema.BaseSchema): void {
+    apply(types: TypeSchemas, schema: JSONSchema.BaseSchema, options: ConversionOptions): void {
         const arraySchema = schema as JSONSchema.ArraySchema;
         
         // Skip if array is already disallowed
@@ -63,7 +63,7 @@ export class ItemsHandler implements PrimitiveHandler {
                  !(arraySchema as any).prefixItems) {
             
             // Convert the item schema and create the typed array
-            const itemSchema = convertJsonSchemaToZod(arraySchema.items);
+            const itemSchema = convertJsonSchemaToZod(arraySchema.items, options);
             let newArray = z.array(itemSchema);
             
             // Apply existing min/max constraints if we already had an array

--- a/src/handlers/primitive/object.ts
+++ b/src/handlers/primitive/object.ts
@@ -1,11 +1,11 @@
 import { z } from "zod/v4";
 import type { JSONSchema } from "zod/v4/core";
-import { PrimitiveHandler, TypeSchemas } from "../../core/types";
+import { ConversionOptions, PrimitiveHandler, TypeSchemas } from "../../core/types";
 import { convertJsonSchemaToZod } from "../../core/converter";
 import { isHazardousPropertyName } from "../../core/utils";
 
 export class PropertiesHandler implements PrimitiveHandler {
-    apply(types: TypeSchemas, schema: JSONSchema.BaseSchema): void {
+    apply(types: TypeSchemas, schema: JSONSchema.BaseSchema, options: ConversionOptions): void {
         const objectSchema = schema as JSONSchema.ObjectSchema;
 
         // Only process if object is still allowed
@@ -52,7 +52,7 @@ export class PropertiesHandler implements PrimitiveHandler {
                     continue;
                 }
 
-                const propertyZod = convertJsonSchemaToZod(propSchema);
+                const propertyZod = convertJsonSchemaToZod(propSchema, options);
                 if (requiredSet.delete(key)) {
                     shape[key] = propertyZod;
                     if (propertyZod.safeParse(undefined).success) {
@@ -81,7 +81,7 @@ export class PropertiesHandler implements PrimitiveHandler {
         } else if (typeof objectSchema.additionalProperties === "object") {
             objectZod = deferUnknownKeys
                 ? objectZod.passthrough()
-                : objectZod.catchall(convertJsonSchemaToZod(objectSchema.additionalProperties));
+                : objectZod.catchall(convertJsonSchemaToZod(objectSchema.additionalProperties, options));
         } else {
             objectZod = objectZod.passthrough();
         }

--- a/src/handlers/primitive/tuple.ts
+++ b/src/handlers/primitive/tuple.ts
@@ -1,10 +1,10 @@
 import { z } from "zod/v4";
 import type { JSONSchema } from "zod/v4/core";
-import { PrimitiveHandler, TypeSchemas } from "../../core/types";
+import { ConversionOptions, PrimitiveHandler, TypeSchemas } from "../../core/types";
 import { convertJsonSchemaToZod } from "../../core/converter";
 
 export class TupleHandler implements PrimitiveHandler {
-    apply(types: TypeSchemas, schema: JSONSchema.BaseSchema): void {
+    apply(types: TypeSchemas, schema: JSONSchema.BaseSchema, options: ConversionOptions): void {
         // Only handle arrays with tuple-style items
         if (schema.type !== "array") return;
 
@@ -17,7 +17,7 @@ export class TupleHandler implements PrimitiveHandler {
         if (types.array === false) return;
 
         // Convert each item schema to Zod schemas
-        const itemSchemas = arraySchema.items.map((itemSchema) => convertJsonSchemaToZod(itemSchema));
+        const itemSchemas = arraySchema.items.map((itemSchema) => convertJsonSchemaToZod(itemSchema, options));
 
         // Create the actual tuple
         let tuple: z.ZodTuple | false;

--- a/src/handlers/refinement/allOf.ts
+++ b/src/handlers/refinement/allOf.ts
@@ -1,14 +1,14 @@
 import { z } from "zod/v4";
 import type { JSONSchema } from "zod/v4/core";
-import { RefinementHandler } from "../../core/types";
+import { ConversionOptions, RefinementHandler } from "../../core/types";
 import { convertJsonSchemaToZod } from "../../core/converter";
 
 export class AllOfHandler implements RefinementHandler {
-    apply(zodSchema: z.ZodTypeAny, schema: JSONSchema.BaseSchema): z.ZodTypeAny {
+    apply(zodSchema: z.ZodTypeAny, schema: JSONSchema.BaseSchema, options: ConversionOptions): z.ZodTypeAny {
         if (!schema.allOf || schema.allOf.length === 0) return zodSchema;
 
         // Convert all schemas in allOf
-        const allOfSchemas = schema.allOf.map(s => convertJsonSchemaToZod(s));
+        const allOfSchemas = schema.allOf.map(s => convertJsonSchemaToZod(s, options));
 
         // Intersect all schemas together, including the base schema
         return allOfSchemas.reduce(

--- a/src/handlers/refinement/anyOf.ts
+++ b/src/handlers/refinement/anyOf.ts
@@ -1,19 +1,19 @@
 import { z } from "zod/v4";
 import type { JSONSchema } from "zod/v4/core";
-import { RefinementHandler } from "../../core/types";
+import { ConversionOptions, RefinementHandler } from "../../core/types";
 import { convertJsonSchemaToZod } from "../../core/converter";
 
 export class AnyOfHandler implements RefinementHandler {
-    apply(zodSchema: z.ZodTypeAny, schema: JSONSchema.BaseSchema): z.ZodTypeAny {
+    apply(zodSchema: z.ZodTypeAny, schema: JSONSchema.BaseSchema, options: ConversionOptions): z.ZodTypeAny {
         if (!schema.anyOf || schema.anyOf.length === 0) return zodSchema;
 
         const anyOfSchema =
             schema.anyOf.length === 1
-                ? convertJsonSchemaToZod(schema.anyOf[0])
+                ? convertJsonSchemaToZod(schema.anyOf[0], options)
                 : z.union([
-                      convertJsonSchemaToZod(schema.anyOf[0]),
-                      convertJsonSchemaToZod(schema.anyOf[1]),
-                      ...schema.anyOf.slice(2).map(s => convertJsonSchemaToZod(s))
+                      convertJsonSchemaToZod(schema.anyOf[0], options),
+                      convertJsonSchemaToZod(schema.anyOf[1], options),
+                      ...schema.anyOf.slice(2).map(s => convertJsonSchemaToZod(s, options))
                   ]);
 
         // Intersect with base schema to preserve existing constraints

--- a/src/handlers/refinement/arrayItems.ts
+++ b/src/handlers/refinement/arrayItems.ts
@@ -1,17 +1,24 @@
 import { z } from "zod/v4";
 import type { JSONSchema } from "zod/v4/core";
-import { RefinementHandler } from "../../core/types";
+import { ConversionOptions, RefinementHandler } from "../../core/types";
 import { convertJsonSchemaToZod } from "../../core/converter";
 import { isValidWithSchema } from "../../core/utils";
 
 export class PrefixItemsHandler implements RefinementHandler {
-    apply(zodSchema: z.ZodTypeAny, schema: JSONSchema.BaseSchema): z.ZodTypeAny {
+    apply(zodSchema: z.ZodTypeAny, schema: JSONSchema.BaseSchema, options: ConversionOptions): z.ZodTypeAny {
         const arraySchema = schema as JSONSchema.ArraySchema;
 
         // Only handle prefixItems (Draft 2020-12 tuples with additional items)
         if ((arraySchema as any).prefixItems && Array.isArray((arraySchema as any).prefixItems)) {
             const prefixItems = (arraySchema as any).prefixItems;
-            const prefixSchemas = prefixItems.map((itemSchema: any) => convertJsonSchemaToZod(itemSchema));
+            const prefixSchemas = prefixItems.map((itemSchema: any) => convertJsonSchemaToZod(itemSchema, options));
+
+            // Convert the additional-items schema once, up front, rather than
+            // on every validation of an array longer than the prefix.
+            const additionalItemSchema =
+                arraySchema.items && typeof arraySchema.items === "object" && !Array.isArray(arraySchema.items)
+                    ? convertJsonSchemaToZod(arraySchema.items, options)
+                    : undefined;
 
             return zodSchema.refine(
                 (value: any) => {
@@ -28,12 +35,7 @@ export class PrefixItemsHandler implements RefinementHandler {
                     if (value.length > prefixSchemas.length) {
                         if (typeof arraySchema.items === "boolean" && arraySchema.items === false) {
                             return false; // No additional items allowed
-                        } else if (
-                            arraySchema.items &&
-                            typeof arraySchema.items === "object" &&
-                            !Array.isArray(arraySchema.items)
-                        ) {
-                            const additionalItemSchema = convertJsonSchemaToZod(arraySchema.items);
+                        } else if (additionalItemSchema !== undefined) {
                             for (let i = prefixSchemas.length; i < value.length; i++) {
                                 if (!isValidWithSchema(additionalItemSchema, value[i])) {
                                     return false;

--- a/src/handlers/refinement/contains.ts
+++ b/src/handlers/refinement/contains.ts
@@ -1,16 +1,16 @@
 import { z } from "zod/v4";
 import type { JSONSchema } from "zod/v4/core";
-import { RefinementHandler } from "../../core/types";
+import { ConversionOptions, RefinementHandler } from "../../core/types";
 import { convertJsonSchemaToZod } from "../../core/converter";
 import { isValidWithSchema } from "../../core/utils";
 
 export class ContainsHandler implements RefinementHandler {
-    apply(zodSchema: z.ZodTypeAny, schema: JSONSchema.BaseSchema): z.ZodTypeAny {
+    apply(zodSchema: z.ZodTypeAny, schema: JSONSchema.BaseSchema, options: ConversionOptions): z.ZodTypeAny {
         const arraySchema = schema as JSONSchema.ArraySchema;
-        
+
         if (arraySchema.contains === undefined) return zodSchema;
 
-        const containsSchema = convertJsonSchemaToZod(arraySchema.contains);
+        const containsSchema = convertJsonSchemaToZod(arraySchema.contains, options);
         const minContains = arraySchema.minContains ?? 1;
         const maxContains = arraySchema.maxContains;
 

--- a/src/handlers/refinement/metadata.ts
+++ b/src/handlers/refinement/metadata.ts
@@ -1,11 +1,15 @@
 import { z } from "zod/v4";
 import type { JSONSchema } from "zod/v4/core";
-import { RefinementHandler } from "../../core/types";
+import { ConversionOptions, RefinementHandler } from "../../core/types";
 
 export class MetadataHandler implements RefinementHandler {
-    apply(zodSchema: z.ZodTypeAny, schema: JSONSchema.BaseSchema): z.ZodTypeAny {
+    apply(zodSchema: z.ZodTypeAny, schema: JSONSchema.BaseSchema, options: ConversionOptions): z.ZodTypeAny {
         if (schema.description) {
             zodSchema = zodSchema.describe(schema.description);
+        }
+        const meta = options.metaForSchema?.(schema);
+        if (meta !== undefined && Object.keys(meta).length > 0) {
+            zodSchema = zodSchema.meta(meta);
         }
         return zodSchema;
     }

--- a/src/handlers/refinement/not.ts
+++ b/src/handlers/refinement/not.ts
@@ -1,14 +1,14 @@
 import { z } from "zod/v4";
 import type { JSONSchema } from "zod/v4/core";
-import { RefinementHandler } from "../../core/types";
+import { ConversionOptions, RefinementHandler } from "../../core/types";
 import { convertJsonSchemaToZod } from "../../core/converter";
 import { isValidWithSchema } from "../../core/utils";
 
 export class NotHandler implements RefinementHandler {
-    apply(zodSchema: z.ZodTypeAny, schema: JSONSchema.BaseSchema): z.ZodTypeAny {
+    apply(zodSchema: z.ZodTypeAny, schema: JSONSchema.BaseSchema, options: ConversionOptions): z.ZodTypeAny {
         if (!(schema as any).not) return zodSchema;
 
-        const notSchema = convertJsonSchemaToZod((schema as any).not);
+        const notSchema = convertJsonSchemaToZod((schema as any).not, options);
         return zodSchema.refine(
             (value: any) => !isValidWithSchema(notSchema, value),
             { message: "Value must not match the 'not' schema" }

--- a/src/handlers/refinement/objectProperties.ts
+++ b/src/handlers/refinement/objectProperties.ts
@@ -1,11 +1,11 @@
 import { z } from "zod/v4";
 import type { JSONSchema } from "zod/v4/core";
-import { RefinementHandler } from "../../core/types";
+import { ConversionOptions, RefinementHandler } from "../../core/types";
 import { convertJsonSchemaToZod } from "../../core/converter";
 import { isHazardousPropertyName } from "../../core/utils";
 
 export class ObjectPropertiesHandler implements RefinementHandler {
-    apply(zodSchema: z.ZodTypeAny, schema: JSONSchema.BaseSchema): z.ZodTypeAny {
+    apply(zodSchema: z.ZodTypeAny, schema: JSONSchema.BaseSchema, options: ConversionOptions): z.ZodTypeAny {
         const objectSchema = schema as JSONSchema.ObjectSchema;
 
         // Skip if no object-specific constraints
@@ -40,7 +40,7 @@ export class ObjectPropertiesHandler implements RefinementHandler {
         // Cache converted property schemas so we only pay the conversion cost once per property.
         const propertySchemas = new Map<string, z.ZodTypeAny>();
         for (const [propName, propSchema] of propertyEntries) {
-            propertySchemas.set(propName, convertJsonSchemaToZod(propSchema));
+            propertySchemas.set(propName, convertJsonSchemaToZod(propSchema, options));
         }
 
         // Precompile patternProperties so each additional key can be checked cheaply.
@@ -52,7 +52,7 @@ export class ObjectPropertiesHandler implements RefinementHandler {
                           try {
                               return {
                                   regex: new RegExp(pattern),
-                                  schema: convertJsonSchemaToZod(patternSchema),
+                                  schema: convertJsonSchemaToZod(patternSchema, options),
                               };
                           } catch {
                               return undefined;
@@ -63,7 +63,7 @@ export class ObjectPropertiesHandler implements RefinementHandler {
 
         const additionalSchema =
             objectSchema.additionalProperties && typeof objectSchema.additionalProperties === "object"
-                ? convertJsonSchemaToZod(objectSchema.additionalProperties)
+                ? convertJsonSchemaToZod(objectSchema.additionalProperties, options)
                 : undefined;
 
         return zodSchema.refine(

--- a/src/handlers/refinement/oneOf.ts
+++ b/src/handlers/refinement/oneOf.ts
@@ -1,14 +1,14 @@
 import { z } from "zod/v4";
 import type { JSONSchema } from "zod/v4/core";
-import { RefinementHandler } from "../../core/types";
+import { ConversionOptions, RefinementHandler } from "../../core/types";
 import { convertJsonSchemaToZod } from "../../core/converter";
 
 export class OneOfHandler implements RefinementHandler {
-    apply(zodSchema: z.ZodTypeAny, schema: JSONSchema.BaseSchema): z.ZodTypeAny {
+    apply(zodSchema: z.ZodTypeAny, schema: JSONSchema.BaseSchema, options: ConversionOptions): z.ZodTypeAny {
         if (!schema.oneOf || schema.oneOf.length === 0) return zodSchema;
 
         // Convert each oneOf schema
-        const oneOfSchemas = schema.oneOf.map(s => convertJsonSchemaToZod(s));
+        const oneOfSchemas = schema.oneOf.map(s => convertJsonSchemaToZod(s, options));
 
         // Apply oneOf validation as a refinement on top of the base schema
         // This preserves other constraints like allOf, anyOf, etc.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,13 @@
 import { z } from "zod/v4";
 import type { JSONSchema } from "zod/v4/core";
 import { convertJsonSchemaToZod } from "./core/converter";
+import type { ConversionOptions } from "./core/types";
 
 // Re-export the main converter function
 export { convertJsonSchemaToZod };
+
+// Re-export conversion options for the public API
+export type { ConversionOptions } from "./core/types";
 
 // Export utilities that tests might depend on
 export { createUniqueItemsValidator, isValidWithSchema } from "./core/utils";
@@ -37,20 +41,29 @@ type InferZodRawShape<T extends Record<string, any>> = {
 /**
  * Converts a JSON Schema object to a Zod raw shape with proper typing
  * @param schema The JSON Schema object to convert
+ * @param options Optional conversion options
  * @returns A Zod raw shape for use with z.object() with inferred types
  */
 export function jsonSchemaObjectToZodRawShape<T extends JSONSchema.Schema & { properties: Record<string, any> }>(
     schema: T,
+    options?: ConversionOptions,
 ): InferZodRawShape<T["properties"]>;
 
 /**
  * Converts a JSON Schema object to a Zod raw shape
  * @param schema The JSON Schema object to convert
+ * @param options Optional conversion options
  * @returns A Zod raw shape for use with z.object()
  */
-export function jsonSchemaObjectToZodRawShape(schema: JSONSchema.Schema): Record<string, z.ZodTypeAny>;
+export function jsonSchemaObjectToZodRawShape(
+    schema: JSONSchema.Schema,
+    options?: ConversionOptions,
+): Record<string, z.ZodTypeAny>;
 
-export function jsonSchemaObjectToZodRawShape(schema: JSONSchema.Schema): Record<string, z.ZodTypeAny> {
+export function jsonSchemaObjectToZodRawShape(
+    schema: JSONSchema.Schema,
+    options?: ConversionOptions,
+): Record<string, z.ZodTypeAny> {
     const raw: Record<string, z.ZodType> = {};
 
     // Get the required fields set for efficient lookup
@@ -60,7 +73,7 @@ export function jsonSchemaObjectToZodRawShape(schema: JSONSchema.Schema): Record
     for (const [key, value] of Object.entries(schema.properties ?? {})) {
         if (value === undefined) continue;
 
-        let zodType = convertJsonSchemaToZod(value);
+        let zodType = convertJsonSchemaToZod(value, options);
 
         // If there's a required array and the field is not in it, make it optional
         // If there's no required array, all fields are optional by default in JSON Schema

--- a/src/meta-for-schema.test.ts
+++ b/src/meta-for-schema.test.ts
@@ -1,0 +1,390 @@
+import { describe, it, expect, vi } from "vitest";
+import { convertJsonSchemaToZod, jsonSchemaObjectToZodRawShape } from "./index";
+import { z } from "zod/v4";
+import type { JSONSchema } from "zod/v4/core";
+
+/**
+ * Example metaForSchema callback: collects all "x-" prefixed keys from a
+ * schema node, returning undefined when there are none.
+ */
+function xKeysMeta(schema: JSONSchema.BaseSchema): Record<string, unknown> | undefined {
+    const meta: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(schema)) {
+        if (key.startsWith("x-")) {
+            meta[key] = value;
+        }
+    }
+    return Object.keys(meta).length > 0 ? meta : undefined;
+}
+
+describe("metaForSchema option", () => {
+    describe("top-level schemas", () => {
+        it("should attach returned metadata to the resulting Zod schema", () => {
+            const zodSchema = convertJsonSchemaToZod(
+                { type: "string", "x-ui-label": "Name", "x-form-position": 1 },
+                { metaForSchema: xKeysMeta },
+            );
+
+            expect(zodSchema.meta()).toEqual({ "x-ui-label": "Name", "x-form-position": 1 });
+            expect(zodSchema.safeParse("hello").success).toBe(true);
+            expect(zodSchema.safeParse(42).success).toBe(false);
+        });
+
+        it("should merge metadata with the schema description", () => {
+            const zodSchema = convertJsonSchemaToZod(
+                { type: "string", description: "User name", "x-ui-label": "Name" },
+                { metaForSchema: xKeysMeta },
+            );
+
+            expect(zodSchema.description).toBe("User name");
+            expect(zodSchema.meta()).toEqual({ description: "User name", "x-ui-label": "Name" });
+        });
+
+        it("should let a description returned by the callback win over the schema description", () => {
+            const zodSchema = convertJsonSchemaToZod(
+                { type: "string", description: "original" },
+                { metaForSchema: () => ({ description: "override" }) },
+            );
+
+            expect(zodSchema.description).toBe("override");
+        });
+
+        it("should not attach metadata when the callback returns undefined", () => {
+            const zodSchema = convertJsonSchemaToZod({ type: "string" }, { metaForSchema: () => undefined });
+
+            expect(zodSchema.meta()).toBeUndefined();
+        });
+
+        it("should not attach metadata when the callback returns an empty object", () => {
+            const zodSchema = convertJsonSchemaToZod({ type: "string" }, { metaForSchema: () => ({}) });
+
+            expect(zodSchema.meta()).toBeUndefined();
+        });
+
+        it("should preserve the description when the callback returns nothing", () => {
+            const zodSchema = convertJsonSchemaToZod(
+                { type: "string", description: "User name" },
+                { metaForSchema: () => undefined },
+            );
+
+            expect(zodSchema.description).toBe("User name");
+        });
+
+        it("should not attach metadata when no options are passed", () => {
+            const zodSchema = convertJsonSchemaToZod({ type: "string", "x-ui-label": "Name" });
+
+            expect(zodSchema.meta()).toBeUndefined();
+        });
+
+        it("should round-trip custom keys through z.toJSONSchema", () => {
+            const jsonSchema = {
+                type: "string",
+                description: "User name",
+                "x-ui-label": "Name",
+                "x-form-position": 1,
+            } as const;
+
+            const zodSchema = convertJsonSchemaToZod(jsonSchema, { metaForSchema: xKeysMeta });
+            const result = z.toJSONSchema(zodSchema);
+
+            expect(result).toEqual({
+                $schema: "https://json-schema.org/draft/2020-12/schema",
+                ...jsonSchema,
+            });
+        });
+    });
+
+    describe("boolean schemas", () => {
+        it("should not invoke the callback for top-level boolean schemas", () => {
+            const metaForSchema = vi.fn(() => ({ "x-a": 1 }));
+
+            const trueSchema = convertJsonSchemaToZod(true, { metaForSchema });
+            const falseSchema = convertJsonSchemaToZod(false, { metaForSchema });
+
+            expect(metaForSchema).not.toHaveBeenCalled();
+            expect(trueSchema.meta()).toBeUndefined();
+            expect(falseSchema.meta()).toBeUndefined();
+        });
+
+        it("should not invoke the callback for nested boolean schemas", () => {
+            const seen: JSONSchema.BaseSchema[] = [];
+            const metaForSchema = (schema: JSONSchema.BaseSchema) => {
+                seen.push(schema);
+                return undefined;
+            };
+
+            convertJsonSchemaToZod(
+                {
+                    type: "object",
+                    properties: { anything: true },
+                },
+                { metaForSchema },
+            );
+
+            expect(seen).not.toContain(true);
+        });
+    });
+
+    describe("nested schemas", () => {
+        it("should attach metadata to object property schemas", () => {
+            const zodSchema = convertJsonSchemaToZod(
+                {
+                    type: "object",
+                    properties: {
+                        name: { type: "string", "x-ui-label": "Name" },
+                        age: { type: "integer", "x-ui-label": "Age" },
+                    },
+                    required: ["name"],
+                },
+                { metaForSchema: xKeysMeta },
+            ) as z.ZodObject<any>;
+
+            expect(zodSchema.shape.name.meta()).toEqual({ "x-ui-label": "Name" });
+            // Optional properties are wrapped in ZodOptional; the metadata
+            // lives on the inner type.
+            expect(zodSchema.shape.age.unwrap().meta()).toEqual({ "x-ui-label": "Age" });
+        });
+
+        it("should round-trip custom keys on object properties through z.toJSONSchema", () => {
+            const zodSchema = convertJsonSchemaToZod(
+                {
+                    type: "object",
+                    properties: {
+                        name: { type: "string", "x-ui-label": "Name" },
+                    },
+                    required: ["name"],
+                    additionalProperties: false,
+                },
+                { metaForSchema: xKeysMeta },
+            );
+
+            const result = z.toJSONSchema(zodSchema) as any;
+            expect(result.properties.name["x-ui-label"]).toBe("Name");
+        });
+
+        it("should attach metadata to array item schemas", () => {
+            const zodSchema = convertJsonSchemaToZod(
+                {
+                    type: "array",
+                    items: { type: "string", "x-kind": "tag" },
+                },
+                { metaForSchema: xKeysMeta },
+            ) as z.ZodArray<any>;
+
+            expect(zodSchema.element.meta()).toEqual({ "x-kind": "tag" });
+        });
+
+        it("should invoke the callback for anyOf member schemas", () => {
+            const seen: JSONSchema.BaseSchema[] = [];
+            const metaForSchema = (schema: JSONSchema.BaseSchema) => {
+                seen.push(schema);
+                return xKeysMeta(schema);
+            };
+
+            const zodSchema = convertJsonSchemaToZod(
+                {
+                    anyOf: [
+                        { type: "string", "x-a": 1 },
+                        { type: "number", "x-b": 2 },
+                    ],
+                },
+                { metaForSchema },
+            );
+
+            expect(seen).toContainEqual({ type: "string", "x-a": 1 });
+            expect(seen).toContainEqual({ type: "number", "x-b": 2 });
+            expect(zodSchema.safeParse("hello").success).toBe(true);
+            expect(zodSchema.safeParse(42).success).toBe(true);
+            expect(zodSchema.safeParse(true).success).toBe(false);
+        });
+
+        it("should invoke the callback for single-member anyOf schemas", () => {
+            const seen: JSONSchema.BaseSchema[] = [];
+            const metaForSchema = (schema: JSONSchema.BaseSchema) => {
+                seen.push(schema);
+                return undefined;
+            };
+
+            convertJsonSchemaToZod({ anyOf: [{ type: "string", "x-a": 1 }] }, { metaForSchema });
+
+            expect(seen).toContainEqual({ type: "string", "x-a": 1 });
+        });
+
+        it("should invoke the callback for oneOf member schemas", () => {
+            const seen: JSONSchema.BaseSchema[] = [];
+            const metaForSchema = (schema: JSONSchema.BaseSchema) => {
+                seen.push(schema);
+                return undefined;
+            };
+
+            convertJsonSchemaToZod(
+                {
+                    oneOf: [
+                        { type: "string", "x-a": 1 },
+                        { type: "number", "x-b": 2 },
+                    ],
+                },
+                { metaForSchema },
+            );
+
+            expect(seen).toContainEqual({ type: "string", "x-a": 1 });
+            expect(seen).toContainEqual({ type: "number", "x-b": 2 });
+        });
+
+        it("should invoke the callback for allOf member schemas", () => {
+            const seen: JSONSchema.BaseSchema[] = [];
+            const metaForSchema = (schema: JSONSchema.BaseSchema) => {
+                seen.push(schema);
+                return undefined;
+            };
+
+            convertJsonSchemaToZod(
+                {
+                    allOf: [{ type: "string", "x-a": 1 }, { minLength: 2 }],
+                },
+                { metaForSchema },
+            );
+
+            expect(seen).toContainEqual({ type: "string", "x-a": 1 });
+            expect(seen).toContainEqual({ minLength: 2 });
+        });
+
+        it("should invoke the callback for not schemas", () => {
+            const seen: JSONSchema.BaseSchema[] = [];
+            const metaForSchema = (schema: JSONSchema.BaseSchema) => {
+                seen.push(schema);
+                return undefined;
+            };
+
+            convertJsonSchemaToZod({ not: { type: "string", "x-a": 1 } }, { metaForSchema });
+
+            expect(seen).toContainEqual({ type: "string", "x-a": 1 });
+        });
+
+        it("should invoke the callback for contains schemas", () => {
+            const seen: JSONSchema.BaseSchema[] = [];
+            const metaForSchema = (schema: JSONSchema.BaseSchema) => {
+                seen.push(schema);
+                return undefined;
+            };
+
+            convertJsonSchemaToZod(
+                {
+                    type: "array",
+                    contains: { type: "number", "x-a": 1 },
+                },
+                { metaForSchema },
+            );
+
+            expect(seen).toContainEqual({ type: "number", "x-a": 1 });
+        });
+
+        it("should invoke the callback for prefixItems schemas", () => {
+            const seen: JSONSchema.BaseSchema[] = [];
+            const metaForSchema = (schema: JSONSchema.BaseSchema) => {
+                seen.push(schema);
+                return undefined;
+            };
+
+            convertJsonSchemaToZod(
+                {
+                    type: "array",
+                    prefixItems: [{ type: "string", "x-a": 1 }, { type: "number" }],
+                    items: { type: "boolean", "x-b": 2 },
+                },
+                { metaForSchema },
+            );
+
+            expect(seen).toContainEqual({ type: "string", "x-a": 1 });
+            expect(seen).toContainEqual({ type: "boolean", "x-b": 2 });
+        });
+
+        it("should invoke the callback for tuple item schemas (legacy items array)", () => {
+            const seen: JSONSchema.BaseSchema[] = [];
+            const metaForSchema = (schema: JSONSchema.BaseSchema) => {
+                seen.push(schema);
+                return undefined;
+            };
+
+            convertJsonSchemaToZod(
+                {
+                    type: "array",
+                    items: [{ type: "string", "x-a": 1 }, { type: "number" }],
+                },
+                { metaForSchema },
+            );
+
+            expect(seen).toContainEqual({ type: "string", "x-a": 1 });
+        });
+
+        it("should invoke the callback for patternProperties and additionalProperties schemas", () => {
+            const seen: JSONSchema.BaseSchema[] = [];
+            const metaForSchema = (schema: JSONSchema.BaseSchema) => {
+                seen.push(schema);
+                return undefined;
+            };
+
+            convertJsonSchemaToZod(
+                {
+                    type: "object",
+                    properties: { a: { type: "string" } },
+                    patternProperties: { "^x-": { type: "number", "x-a": 1 } },
+                    additionalProperties: { type: "boolean", "x-b": 2 },
+                },
+                { metaForSchema },
+            );
+
+            expect(seen).toContainEqual({ type: "number", "x-a": 1 });
+            expect(seen).toContainEqual({ type: "boolean", "x-b": 2 });
+        });
+    });
+
+    describe("jsonSchemaObjectToZodRawShape", () => {
+        it("should pass options through to property conversions", () => {
+            const raw = jsonSchemaObjectToZodRawShape(
+                {
+                    type: "object",
+                    properties: {
+                        name: { type: "string", "x-ui-label": "Name" },
+                        age: { type: "integer", "x-ui-label": "Age" },
+                    },
+                    required: ["name"],
+                },
+                { metaForSchema: xKeysMeta },
+            );
+
+            expect((raw.name as z.ZodTypeAny).meta()).toEqual({ "x-ui-label": "Name" });
+            // Non-required properties are wrapped in ZodOptional.
+            expect((raw.age as z.ZodOptional<z.ZodTypeAny>).unwrap().meta()).toEqual({ "x-ui-label": "Age" });
+        });
+
+        it("should not attach metadata when no options are passed", () => {
+            const raw = jsonSchemaObjectToZodRawShape({
+                type: "object",
+                properties: { name: { type: "string", "x-ui-label": "Name" } },
+                required: ["name"],
+            });
+
+            expect((raw.name as z.ZodTypeAny).meta()).toBeUndefined();
+        });
+    });
+
+    describe("issue #32 example", () => {
+        it("should preserve custom metadata fields from the issue example", () => {
+            const jsonSchema = {
+                type: "string",
+                description: "User name",
+                "x-ui-label": "Name",
+                "x-form-position": 1,
+            };
+
+            const zodSchema = convertJsonSchemaToZod(jsonSchema, { metaForSchema: xKeysMeta });
+
+            expect(zodSchema.meta()).toEqual({
+                description: "User name",
+                "x-ui-label": "Name",
+                "x-form-position": 1,
+            });
+        });
+    });
+});


### PR DESCRIPTION
Closes #32.

## What

Adds an optional `options` argument to `convertJsonSchemaToZod` and `jsonSchemaObjectToZodRawShape`:

```typescript
const zodSchema = convertJsonSchemaToZod(jsonSchema, {
    metaForSchema: (schema) => {
        const meta = Object.fromEntries(
            Object.entries(schema).filter(([key]) => key.startsWith("x-"))
        );
        return Object.keys(meta).length > 0 ? meta : undefined;
    },
});
```

The `metaForSchema` callback is invoked for every (non-boolean) JSON Schema node that produces a Zod type — including nested ones (object properties, array items, `anyOf`/`oneOf`/`allOf` members, `patternProperties`, `additionalProperties`, `contains`, `not`, tuple items, `prefixItems`). If it returns a non-empty object, that object is attached to the resulting Zod type via [`.meta()`](https://zod.dev/metadata).

Custom keys round-trip: `z.toJSONSchema()` emits the attached metadata back into the output JSON Schema.

## Why a callback instead of the deny-list proposed in #32

A built-in list of "standard" JSON Schema keywords has to be kept complete across drafts and conventions (the list proposed in the issue was already missing `format`, `default`, and the `content*` keywords). The callback moves that policy to the caller entirely, supports arbitrary conventions (not just `x-` prefixes), and is fully opt-in — no behavior change and no `z.globalRegistry` entries for existing users.

## Semantics

- The returned metadata merges with the schema's `description` (applied via `.describe()` as before); a `description` key returned by the callback wins.
- `undefined` or an empty object means no `.meta()` call.
- Boolean schemas (`true`/`false`) never trigger the callback.
- The callback must be pure: a node may be converted more than once, and some resulting Zod types are only used internally for validation.
- Metadata attaches to the type a node produces directly; wrappers added afterwards (e.g. `.optional()` for non-required properties) sit outside it.

## Implementation notes

- `ConversionOptions` is threaded through both handler interfaces and all recursive conversion call sites; the metadata is applied by `MetadataHandler`, which already runs last.
- Drive-by fix: `PrefixItemsHandler` used to convert the additional-`items` schema inside its refinement closure, i.e. on every validation of an array longer than the prefix. That conversion is now hoisted to conversion time (also needed so the callback fires during conversion, not parsing).

## Testing

- 25 new tests in `src/meta-for-schema.test.ts` (written first), covering top-level and nested attachment, description merge/override, undefined/empty returns, boolean schemas, `jsonSchemaObjectToZodRawShape`, `z.toJSONSchema` round-trips, and the exact example from #32.
- Full suite: 1235 passed. Coverage is unchanged from main (branch coverage 96.21% vs 96.16%; the uncovered lines pre-exist in files this PR doesn't touch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)