### PR TITLE
Translate draft-4 boolean exclusiveMinimum/exclusiveMaximum instead of disabling the number type

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,8 @@ This library provides comprehensive support for JSON Schema Draft 2020-12 featur
 - `exclusiveMaximum` - Exclusive maximum (less than)
 - `multipleOf` - Multiple validation with floating-point precision handling
 
+**Draft-4 Compatibility**: The legacy boolean form of `exclusiveMinimum`/`exclusiveMaximum` (e.g. `{ "minimum": 5, "exclusiveMinimum": true }`, as used by draft-4 and Swagger 2.0) is also accepted: `true` makes the sibling `minimum`/`maximum` bound exclusive, and `false` is a no-op.
+
 ### Array Validations
 - `items` - Item schema validation (supports schemas, boolean values, and arrays)
 - `prefixItems` - Tuple-style positional item validation (Draft 2020-12)

--- a/src/draft4-exclusive-bounds.test.ts
+++ b/src/draft4-exclusive-bounds.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect } from "vitest";
+import { z } from "zod/v4";
+import type { JSONSchema } from "zod/v4/core";
+import { convertJsonSchemaToZod } from "./index";
+
+// Regression tests for issue #45: the JSON Schema draft-4 boolean form of
+// exclusiveMinimum/exclusiveMaximum must never disable the number type.
+// exclusiveMinimum: true with a numeric sibling `minimum` makes the bound
+// exclusive; exclusiveMinimum: false (or a boolean without a numeric
+// sibling bound) is a no-op. Mirror semantics for exclusiveMaximum.
+describe("Draft-4 boolean exclusiveMinimum/exclusiveMaximum (issue #45)", () => {
+    it("treats exclusiveMinimum: true with minimum as an exclusive lower bound", () => {
+        const schema = convertJsonSchemaToZod({
+            type: "number",
+            minimum: 5,
+            exclusiveMinimum: true,
+        });
+
+        expect(schema.safeParse(10).success).toBe(true);
+        expect(schema.safeParse(6).success).toBe(true);
+        expect(schema.safeParse(5).success).toBe(false);
+        expect(schema.safeParse(4).success).toBe(false);
+        expect(schema.safeParse("6").success).toBe(false);
+    });
+
+    it("treats exclusiveMaximum: true with maximum as an exclusive upper bound", () => {
+        const schema = convertJsonSchemaToZod({
+            type: "number",
+            maximum: 5,
+            exclusiveMaximum: true,
+        });
+
+        expect(schema.safeParse(4).success).toBe(true);
+        expect(schema.safeParse(5).success).toBe(false);
+        expect(schema.safeParse(6).success).toBe(false);
+    });
+
+    it("treats exclusiveMinimum: false as a no-op (minimum stays inclusive)", () => {
+        const schema = convertJsonSchemaToZod({
+            type: "number",
+            minimum: 5,
+            exclusiveMinimum: false,
+        });
+
+        expect(schema.safeParse(5).success).toBe(true);
+        expect(schema.safeParse(6).success).toBe(true);
+        expect(schema.safeParse(4).success).toBe(false);
+    });
+
+    it("treats exclusiveMaximum: false as a no-op (maximum stays inclusive)", () => {
+        const schema = convertJsonSchemaToZod({
+            type: "number",
+            maximum: 5,
+            exclusiveMaximum: false,
+        });
+
+        expect(schema.safeParse(5).success).toBe(true);
+        expect(schema.safeParse(4).success).toBe(true);
+        expect(schema.safeParse(6).success).toBe(false);
+    });
+
+    it("never disables number for exclusiveMinimum: true without a minimum", () => {
+        const schema = convertJsonSchemaToZod({
+            type: "number",
+            exclusiveMinimum: true,
+        });
+
+        expect(schema.safeParse(0).success).toBe(true);
+        expect(schema.safeParse(-100).success).toBe(true);
+    });
+
+    it("never disables number for exclusiveMaximum: true without a maximum", () => {
+        const schema = convertJsonSchemaToZod({
+            type: "number",
+            exclusiveMaximum: true,
+        });
+
+        expect(schema.safeParse(0).success).toBe(true);
+        expect(schema.safeParse(100).success).toBe(true);
+    });
+
+    it("supports a combined draft-4 exclusive range", () => {
+        const schema = convertJsonSchemaToZod({
+            type: "number",
+            minimum: 0,
+            maximum: 10,
+            exclusiveMinimum: true,
+            exclusiveMaximum: true,
+        });
+
+        expect(schema.safeParse(0).success).toBe(false);
+        expect(schema.safeParse(10).success).toBe(false);
+        expect(schema.safeParse(0.5).success).toBe(true);
+        expect(schema.safeParse(5).success).toBe(true);
+        expect(schema.safeParse(-1).success).toBe(false);
+        expect(schema.safeParse(11).success).toBe(false);
+    });
+
+    it("applies the boolean form to integer schemas", () => {
+        const schema = convertJsonSchemaToZod({
+            type: "integer",
+            minimum: 5,
+            exclusiveMinimum: true,
+        });
+
+        expect(schema.safeParse(6).success).toBe(true);
+        expect(schema.safeParse(5).success).toBe(false);
+        expect(schema.safeParse(5.5).success).toBe(false);
+    });
+
+    it("keeps numeric exclusiveMinimum/exclusiveMaximum behavior unchanged", () => {
+        const schema = convertJsonSchemaToZod({
+            type: "number",
+            exclusiveMinimum: 0,
+            exclusiveMaximum: 100,
+        });
+
+        expect(schema.safeParse(0).success).toBe(false);
+        expect(schema.safeParse(1).success).toBe(true);
+        expect(schema.safeParse(100).success).toBe(false);
+        expect(schema.safeParse(99).success).toBe(true);
+    });
+
+    it("does not disable number for exclusiveMaximum: true with a non-numeric sibling maximum", () => {
+        const malformed = {
+            type: "number",
+            exclusiveMaximum: true,
+            maximum: "x",
+        } as unknown as JSONSchema.BaseSchema;
+        const schema = convertJsonSchemaToZod(malformed);
+
+        // The malformed `maximum: "x"` check itself rejects the value
+        // (pre-existing MaximumHandler behavior), but the number type
+        // must no longer be dropped to `never` by the boolean
+        // exclusiveMaximum.
+        const result = schema.safeParse(7);
+        expect(result.success).toBe(false);
+        expect(result.error?.issues[0]?.code).toBe("too_big");
+    });
+});

--- a/src/handlers/primitive/number.ts
+++ b/src/handlers/primitive/number.ts
@@ -40,9 +40,17 @@ export class ExclusiveMinimumHandler implements PrimitiveHandler {
             if (currentNumber instanceof z.ZodNumber) {
                 if (typeof numberSchema.exclusiveMinimum === "number") {
                     types.number = currentNumber.gt(numberSchema.exclusiveMinimum);
-                } else {
-                    types.number = false;
+                } else if (
+                    numberSchema.exclusiveMinimum === true &&
+                    typeof numberSchema.minimum === "number"
+                ) {
+                    // Draft-4 boolean form: exclusiveMinimum: true turns
+                    // the sibling `minimum` into an exclusive bound.
+                    types.number = currentNumber.gt(numberSchema.minimum);
                 }
+                // exclusiveMinimum: false, or a boolean form without a
+                // numeric sibling minimum, is a no-op — never disable
+                // the number type.
             }
         }
     }
@@ -58,9 +66,17 @@ export class ExclusiveMaximumHandler implements PrimitiveHandler {
             if (currentNumber instanceof z.ZodNumber) {
                 if (typeof numberSchema.exclusiveMaximum === "number") {
                     types.number = currentNumber.lt(numberSchema.exclusiveMaximum);
-                } else {
-                    types.number = false;
+                } else if (
+                    numberSchema.exclusiveMaximum === true &&
+                    typeof numberSchema.maximum === "number"
+                ) {
+                    // Draft-4 boolean form: exclusiveMaximum: true turns
+                    // the sibling `maximum` into an exclusive bound.
+                    types.number = currentNumber.lt(numberSchema.maximum);
                 }
+                // exclusiveMaximum: false, or a boolean form without a
+                // numeric sibling maximum, is a no-op — never disable
+                // the number type.
             }
         }
     }


### PR DESCRIPTION
## Problem

When a schema uses the JSON Schema draft-4 boolean form of `exclusiveMinimum`/`exclusiveMaximum` (e.g. `{ "minimum": 5, "exclusiveMinimum": true }`, as emitted by Swagger 2.0 tooling), the handlers in `src/handlers/primitive/number.ts` set `types.number = false`, removing the number branch from the resulting union. Every numeric value was then rejected with `expected never, received number`.

## Fix

Per the maintainer guidance on the issue (option 1), the legacy boolean form is now translated instead of disabling the number type:

- `exclusiveMinimum: true` with a numeric sibling `minimum` applies `.gt(minimum)`
- `exclusiveMinimum: false` is a no-op (the `minimum` stays inclusive)
- a boolean `exclusiveMinimum` without a numeric sibling `minimum` is a no-op — the number type is never disabled
- exact mirror for `exclusiveMaximum`/`maximum` with `.lt(maximum)`

The draft 2020-12 numeric form of both keywords is byte-for-byte unchanged, so no official-test-suite results change (the suite contains no boolean-form cases and the skip list has no `exclusive*` entries). The README's Number Validations section now documents the draft-4 compatibility behavior.

## Tests

Tests were written first, in a new `src/draft4-exclusive-bounds.test.ts`: 9 of the 10 tests fail on the unfixed code (the tenth is the numeric-form regression guard) and all pass after the fix. They cover the issue's reproduction, both boolean values of each keyword, missing and non-numeric sibling bounds, a combined exclusive range, `type: "integer"`, and the numeric form.

Full suite: 1223 passed / 246 skipped. Coverage strictly improved — lines 99.57% → 100%, branches 96.17% → 96.61% (the previously uncovered `types.number = false` lines are gone; every new branch is covered; the remaining partial branches are pre-existing defensive fallbacks shared by all number handlers). `npm run build` succeeds.

Fixes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)