### PR TITLE
Enforce required for properties that have a default

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ This library provides comprehensive support for JSON Schema Draft 2020-12 featur
 ### Additional Features
 - `title` - Schema titles (carried over to Zod schemas)
 - `description` - Schema descriptions (carried over to Zod schemas)
-- `default` - Default value annotation, but ignored if it doesn't conform to the schema
+- `default` - Default value annotation, but ignored if it doesn't conform to the schema; a default never satisfies `required` for a missing property
 - Boolean schemas (`true` = allow anything, `false` = allow nothing)
 - Implicit type detection from constraints
 - Comprehensive error messages
@@ -274,7 +274,6 @@ The following JSON Schema features are **not yet implemented**:
 Beyond the unsupported keywords above, supported features have some known gaps:
 
 - **`__proto__` properties**: Zod removes own `__proto__` keys from parsed objects to prevent prototype pollution, and this library's validation runs on Zod's parse output. As a result, a `__proto__` entry in `properties` cannot validate its value, and `required: ["__proto__"]` is only enforced for schemas without an explicit `type`.
-- **`required` interacting with `default`**: When a required property's schema has a `default`, the default fills in missing keys before validation runs, so `required` is effectively not enforced for that property.
 - **`unevaluatedProperties` is ignored**: In particular, discriminated unions whose `oneOf` variants differ only by `unevaluatedProperties: false` will not reject inputs that mix properties from different variants. Declaring `required` properties in each variant makes the variants distinguishable instead.
 
 ## Standards Compliance

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -8,7 +8,7 @@ export interface TypeSchemas {
     null?: z.ZodNull | false;
     array?: z.ZodArray<any> | false;
     tuple?: z.ZodTuple | false;
-    object?: z.ZodObject<any> | false;
+    object?: z.ZodTypeAny | false;
     file?: z.ZodFile | false;
 }
 

--- a/src/handlers/primitive/object.ts
+++ b/src/handlers/primitive/object.ts
@@ -86,17 +86,30 @@ export class PropertiesHandler implements PrimitiveHandler {
             objectZod = objectZod.passthrough();
         }
 
-        // Refinements run on Zod's parse output, which strips own "__proto__"
-        // keys for security, so presence of "__proto__" can't be enforced here.
-        // (ProtoRequiredHandler covers the untyped-schema case.)
+        // Presence of required "__proto__" stays unenforced to keep the
+        // documented __proto__ limitation consistent: Zod strips own
+        // "__proto__" keys for security, so its value can't be validated
+        // either. (ProtoRequiredHandler covers the untyped-schema case.)
         const enforcibleKeys = presenceCheckKeys.filter((key) => key !== "__proto__");
 
         if (enforcibleKeys.length > 0) {
-            types.object = objectZod.refine(
-                (value: Record<string, unknown>) =>
-                    enforcibleKeys.every((key) => Object.prototype.hasOwnProperty.call(value, key)),
-                { message: `Missing required properties: ${enforcibleKeys.join(", ")}` },
-            );
+            // Check presence on the RAW input, before objectZod parses it:
+            // the parse output can't distinguish a missing key from one
+            // materialized by a `default`, and JSON Schema `required` must
+            // reject a missing key even when its schema has a default.
+            // Non-objects pass through so objectZod rejects them with its
+            // own error (the guard also keeps hasOwnProperty off null).
+            const hasRequiredKeys = (value: unknown): boolean =>
+                typeof value !== "object" || value === null || Array.isArray(value)
+                    ? true
+                    : enforcibleKeys.every((key) => Object.prototype.hasOwnProperty.call(value, key));
+
+            types.object = z
+                .any()
+                .refine(hasRequiredKeys, {
+                    message: `Missing required properties: ${enforcibleKeys.join(", ")}`,
+                })
+                .pipe(objectZod);
         } else {
             types.object = objectZod;
         }

--- a/src/handlers/refinement/objectProperties.ts
+++ b/src/handlers/refinement/objectProperties.ts
@@ -40,8 +40,11 @@ export class ObjectPropertiesHandler implements RefinementHandler {
 
         // A plain object schema already enforces properties, required, and
         // additionalProperties through its shape, so refinement is only needed
-        // for constraints the shape can't express.
-        const isDirectObject = zodSchema instanceof z.ZodObject || zodSchema instanceof z.ZodRecord;
+        // for constraints the shape can't express. PropertiesHandler may have
+        // piped a raw-input required-presence check in front of the object
+        // schema; unwrap the pipe so those schemas keep early-returning too.
+        const baseSchema = zodSchema instanceof z.ZodPipe ? zodSchema.out : zodSchema;
+        const isDirectObject = baseSchema instanceof z.ZodObject || baseSchema instanceof z.ZodRecord;
         if (isDirectObject && !hasPatternConstraints && !hasHazardousProperties) {
             return zodSchema;
         }

--- a/src/object-properties.test.ts
+++ b/src/object-properties.test.ts
@@ -47,6 +47,122 @@ describe("required property presence", () => {
     });
 });
 
+describe("required is enforced for properties that have a default (issue #42)", () => {
+    it("rejects a missing required property even when it has a default", () => {
+        const zodSchema = convertJsonSchemaToZod({
+            type: "object",
+            properties: { foo: { type: "string", default: "x" } },
+            required: ["foo"],
+        } as any);
+        expect(zodSchema.safeParse({}).success).toBe(false);
+    });
+
+    it("keeps validating present values and does not overwrite them", () => {
+        const zodSchema = convertJsonSchemaToZod({
+            type: "object",
+            properties: { foo: { type: "string", default: "x" } },
+            required: ["foo"],
+        } as any);
+        const good = zodSchema.safeParse({ foo: "y" });
+        expect(good.success).toBe(true);
+        expect(good.data).toEqual({ foo: "y" });
+        expect(zodSchema.safeParse({ foo: 5 }).success).toBe(false);
+    });
+
+    it("rejects non-object inputs through the piped object schema", () => {
+        const zodSchema = convertJsonSchemaToZod({
+            type: "object",
+            properties: { foo: { type: "string", default: "x" } },
+            required: ["foo"],
+        } as any);
+        expect(zodSchema.safeParse("hello").success).toBe(false);
+        expect(zodSchema.safeParse(null).success).toBe(false);
+        expect(zodSchema.safeParse([]).success).toBe(false);
+        expect(zodSchema.safeParse(42).success).toBe(false);
+    });
+
+    it("works together with additionalProperties: false", () => {
+        const zodSchema = convertJsonSchemaToZod({
+            type: "object",
+            properties: { foo: { type: "string", default: "x" } },
+            required: ["foo"],
+            additionalProperties: false,
+        } as any);
+        expect(zodSchema.safeParse({}).success).toBe(false);
+        expect(zodSchema.safeParse({ foo: "y", extra: 1 }).success).toBe(false);
+        expect(zodSchema.safeParse({ foo: "y" }).success).toBe(true);
+    });
+
+    it("enforces required-with-default when no explicit type is given", () => {
+        const zodSchema = convertJsonSchemaToZod({
+            properties: { foo: { type: "string", default: "x" } },
+            required: ["foo"],
+        } as any);
+        expect(zodSchema.safeParse({}).success).toBe(false);
+        expect(zodSchema.safeParse({ foo: "y" }).success).toBe(true);
+        // JSON Schema: required only constrains objects.
+        expect(zodSchema.safeParse("not an object").success).toBe(true);
+    });
+
+    it("enforces required-with-default in nested objects", () => {
+        const zodSchema = convertJsonSchemaToZod({
+            type: "object",
+            properties: {
+                cfg: {
+                    type: "object",
+                    properties: { mode: { type: "string", default: "auto" } },
+                    required: ["mode"],
+                },
+            },
+            required: ["cfg"],
+        } as any);
+        expect(zodSchema.safeParse({ cfg: {} }).success).toBe(false);
+        expect(zodSchema.safeParse({}).success).toBe(false);
+        expect(zodSchema.safeParse({ cfg: { mode: "m" } }).success).toBe(true);
+    });
+
+    it("keeps applying defaults for non-required missing properties", () => {
+        const zodSchema = convertJsonSchemaToZod({
+            type: "object",
+            properties: {
+                foo: { type: "string", default: "x" },
+                bar: { type: "number", default: 1 },
+            },
+            required: ["foo"],
+        } as any);
+        const result = zodSchema.safeParse({ foo: "y" });
+        expect(result.success).toBe(true);
+        expect(result.data).toEqual({ foo: "y", bar: 1 });
+    });
+
+    it("enforces required-with-default for hazardous property names", () => {
+        const zodSchema = convertJsonSchemaToZod({
+            type: "object",
+            properties: { toString: { type: "string", default: "x" } },
+            required: ["toString"],
+        } as any);
+        expect(zodSchema.safeParse({}).success).toBe(false);
+        expect(zodSchema.safeParse(JSON.parse('{"toString": "y"}')).success).toBe(true);
+    });
+
+    it("still applies a top-level default on an optional nested object", () => {
+        const zodSchema = convertJsonSchemaToZod({
+            type: "object",
+            properties: {
+                cfg: {
+                    type: "object",
+                    properties: { mode: { type: "string" } },
+                    required: ["mode"],
+                    default: { mode: "auto" },
+                },
+            },
+        } as any);
+        const result = zodSchema.safeParse({});
+        expect(result.success).toBe(true);
+        expect(result.data).toEqual({ cfg: { mode: "auto" } });
+    });
+});
+
 describe("properties named like Object.prototype members", () => {
     it("treats inherited members as absent", () => {
         const zodSchema = convertJsonSchemaToZod({


### PR DESCRIPTION
## Problem

When a property's schema has a `default` and the property is listed in `required`, a missing key still validated:

```ts
const schema = convertJsonSchemaToZod({
    type: "object",
    properties: { foo: { type: "string", default: "x" } },
    required: ["foo"],
});
schema.safeParse({}).success; // was true, data { foo: "x" }
```

The required-presence check ran as a Zod refinement on the parse output, where the `default` had already materialized the key, so the check could not distinguish a missing key from an applied default.

## Fix

Per maintainer decision, enforce strict JSON Schema semantics: a property listed in `required` must be present in the **raw** input, even if its schema has a default.

- `PropertiesHandler` (src/handlers/primitive/object.ts): when any required key needs an explicit presence check (hazardous names, keys without a property schema, or property schemas that accept `undefined` — which now includes schemas with defaults), the check runs on the raw input via `z.any().refine(hasRequiredKeys).pipe(objectZod)` instead of a post-parse refinement. Non-object inputs pass the raw check so the piped object schema rejects them with its own error.
- `ObjectPropertiesHandler` (src/handlers/refinement/objectProperties.ts): unwraps the presence-check pipe (`z.ZodPipe` → `.out`) so plain object schemas keep early-returning instead of gaining a redundant post-parse refinement.
- `TypeSchemas.object` (src/core/types.ts): widened from `z.ZodObject<any> | false` to `z.ZodTypeAny | false`, since the pipe is not a `ZodObject` (compile-time only change).
- README: removed the corresponding Known Limitations bullet and noted under `default` that a default never satisfies `required`.

## Behavior change (intentional)

This moves from Ajv-`useDefaults` semantics (defaults inserted, then `required` passes) to strict JSON Schema validation (missing required key rejects, even with a default). No existing tests asserted the old behavior. Defaults keep working for non-required missing properties — this is locked in by a new test.

Two smaller consequences worth noting:
- For schemas where some required key accepts `undefined` or has a default, `convertJsonSchemaToZod` now returns a `ZodPipe` instead of a refined `ZodObject`; downstream code introspecting `.shape` on that (undocumented) result shape would need `.out`.
- Missing-required failures now surface from the pipe's input stage, so issue paths differ slightly; the error message text (`Missing required properties: ...`) is unchanged.

Residual known gaps, not addressed here: `required` inside combinators (e.g. `allOf`) still runs on parse output and thus still sees materialized defaults; `min/maxProperties` still count materialized defaults; `required: ["__proto__"]` on typed objects intentionally stays unenforced to keep the documented `__proto__` limitation consistent (the raw-input check could now support it — possible follow-up).

## Tests

Tests were written first and confirmed to fail on the unfixed code (4 failing repro tests, including nested objects, `additionalProperties: false`, and the no-explicit-type union path), plus regression guards: present values are not overwritten, defaults still apply to non-required properties, non-object inputs, hazardous property names, and a top-level `default` on an optional nested object schema.

Full suite: 1222 passed / 246 skipped (skip list unchanged — no official-suite cases flip in either direction: `default.json` cases lack `required`, `required.json` cases lack `default`). All touched files at 100% line/branch coverage; overall coverage identical to `main`'s baseline. `npm run build` passes.

Fixes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)